### PR TITLE
Add gnutls as dependency

### DIFF
--- a/README.org
+++ b/README.org
@@ -142,6 +142,12 @@ A canonical version of Emacs for macOS can be found at https://emacsformacosx.co
 
 ** Install dependencies
 
+[[https://github.com/railwaycat/homebrew-emacsmacport/releases][Emacs-mac]] port relies on [[https://www.gnutls.org][GnuTLS]] library to make TLS/SSL connections. Install it:
+
+#+BEGIN_SRC sh
+brew install gnutls
+#+END_SRC
+
 Castlemacs relies on [[https://github.com/ggreer/the_silver_searcher][The Silver Searcher]] to quickly search within a project. Install it:
 
 #+BEGIN_SRC sh


### PR DESCRIPTION
I'm doing clean install via homebrew:

```
brew tap railwaycat/emacsmacport
brew cask install emacsmacport
git clone https://github.com/freetonik/castlemacs ~/.emacs.d
```

After launching Emacs I've got an error:

```
error: Package 'use-package-' is unavailable
Opening TLS connection with ‘gnutls-cli --x509cafile /etc/ssl/cert.pem -p 443 melpa.org --protocols ssl3’...failed
```

Looks like this version of Emacs is using GnuTLS library. After installing gnutls via homebrew the issue was resolved. Perhaps this should be mentioned in the "Installing dependencies" section of the documentation?